### PR TITLE
feat(headers): configurable client header forwarding with explicit ov…

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -55,3 +55,15 @@ VERBOSE=false            # Options: true, false
 # nested -> tools: [{ type: 'function', function: { name, ... } }]
 # flat   -> tools: [{ type: 'function', name, ... }]
 # UPSTREAM_TOOLS_FORMAT=nested
+
+# ------------------
+# Client header forwarding (optional)
+# ------------------
+# Controls forwarding of client headers to upstream to preserve client characteristics
+# off       -> do not forward (default)
+# safe      -> forward UA, Accept-Language, sec-ch-*, X-Forwarded-For, etc.
+# list      -> forward only headers listed below (comma-separated); values come from client request
+# override  -> set final header values from JSON map below
+# FORWARD_CLIENT_HEADERS_MODE=off
+# FORWARD_CLIENT_HEADERS_LIST=User-Agent,Accept-Language
+# FORWARD_CLIENT_HEADERS_OVERRIDE={"User-Agent":"MyApp/1.2.3","Accept":"text/event-stream"}

--- a/src/routes/ollama.ts
+++ b/src/routes/ollama.ts
@@ -40,6 +40,8 @@ ollama.post("/chat", openaiAuthMiddleware(), async (c) => {
 
 	const { response: upstream, error: errorResp } = await startUpstreamRequest(c.env, model, inputItems, {
 		instructions: instructions
+		,
+		forwardedClientHeaders: c.req.raw.headers
 	});
 
 	if (errorResp) {
@@ -127,7 +129,8 @@ ollama.post("/show", openaiAuthMiddleware(), async (c) => {
 		[], // No input items for /api/show
 		{
 			ollamaPath: "/api/show", // Specify the Ollama API path
-			ollamaPayload: payload // Pass the original payload
+			ollamaPayload: payload, // Pass the original payload
+			forwardedClientHeaders: c.req.raw.headers
 		}
 	);
 
@@ -156,7 +159,8 @@ ollama.get("/tags", async (c) => {
 		"", // No specific model for /api/tags
 		[], // No input items
 		{
-			ollamaPath: "/api/tags" // Specify the Ollama API path
+			ollamaPath: "/api/tags", // Specify the Ollama API path
+			forwardedClientHeaders: c.req.raw.headers
 		}
 	);
 

--- a/src/routes/openai.ts
+++ b/src/routes/openai.ts
@@ -95,7 +95,8 @@ openai.post("/v1/chat/completions", openaiAuthMiddleware(), async (c) => {
 		tools: toolsResponses,
 		toolChoice: toolChoice,
 		parallelToolCalls: parallelToolCalls,
-		reasoningParam: reasoningParam
+		reasoningParam: reasoningParam,
+		forwardedClientHeaders: c.req.raw.headers
 	});
 
 	if (verbose) {
@@ -277,7 +278,8 @@ openai.post("/v1/completions", openaiAuthMiddleware(), async (c) => {
 
 	const { response: upstream, error: errorResp } = await startUpstreamRequest(c.env, model, inputItems, {
 		instructions: instructions,
-		reasoningParam: reasoningParam
+		reasoningParam: reasoningParam,
+		forwardedClientHeaders: c.req.raw.headers
 	});
 
 	if (errorResp) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,19 @@ export interface Env {
 	//   - "nested" (default): tools[].function.name (OpenAI Responses style)
 	//   - "flat": tools[].name (some third-party providers)
 	UPSTREAM_TOOLS_FORMAT?: "nested" | "flat";
+
+	// --- Client header forwarding controls ---
+	// Controls how incoming client headers are forwarded to the upstream.
+	//   - "off" (default): do not forward client headers
+	//   - "safe": forward a safe allowlist (UA, Accept-Language, sec-ch-* , X-Forwarded-For, etc.)
+	//   - "list": forward only headers explicitly listed in FORWARD_CLIENT_HEADERS_LIST
+	//   - "override": after building default headers, override final headers using explicit key-value map
+	FORWARD_CLIENT_HEADERS_MODE?: "off" | "safe" | "list" | "override";
+	// When mode = "override": JSON string mapping header names to values, e.g.
+	// '{"User-Agent":"MyApp/1.0","Accept":"text/event-stream"}'
+	FORWARD_CLIENT_HEADERS_OVERRIDE?: string;
+	// Comma-separated header names (case-insensitive) used when mode = "list"
+	FORWARD_CLIENT_HEADERS_LIST?: string;
 }
 
 export type AuthTokens = {


### PR DESCRIPTION
…erride; docs and examples

- Add FORWARD_CLIENT_HEADERS_MODE: off (default) | safe | list | override
- list: forward only headers named in FORWARD_CLIENT_HEADERS_LIST; values come from the client request
- override: set final upstream header values via FORWARD_CLIENT_HEADERS_OVERRIDE (JSON map)
- Never override Authorization; in non-override modes also keep Content-Type, Accept, OpenAI-Beta, chatgpt-account-id, session_id intact
- Enforce Accept: text/event-stream for SSE in default/safe/list; allow changing it in override (logs a warning)
- Apply forwarding before auth/protocol headers; apply override after building defaults and also on 401 retry
- Pass through original request headers from routes to upstream builder

Implementation

- src/types.ts: add FORWARD_CLIENT_HEADERS_MODE, FORWARD_CLIENT_HEADERS_LIST, FORWARD_CLIENT_HEADERS_OVERRIDE to Env
- src/upstream.ts: implement safe/list forwarding and explicit override map; preserve reserved headers; warn on Accept override; minor TS fix for optional account id in retry path
- src/routes/openai.ts, src/routes/ollama.ts: pass c.req.raw.headers as forwardedClientHeaders

Docs

- README.md: document modes, examples, and SSE/Authorization caveats
- .dev.vars.example: add sample config for list and override

Notes

- Host header is not user-overridable; it is derived from the target requestUrl. Use X-Forwarded-* if upstream needs original host info.

Build

- tsc passes; wrangler dry-run build succeeds